### PR TITLE
feat: 사용자의 위치로부터 N 미터 이내의 음식점을 조회하는 API 구현

### DIFF
--- a/src/main/java/com/kimandkang/rouleatt/RouleattApplication.java
+++ b/src/main/java/com/kimandkang/rouleatt/RouleattApplication.java
@@ -1,0 +1,13 @@
+package com.kimandkang.rouleatt;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class RouleattApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(RouleattApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/kimandkang/rouleatt/controller/RestaurantController.java
+++ b/src/main/java/com/kimandkang/rouleatt/controller/RestaurantController.java
@@ -1,0 +1,27 @@
+package com.kimandkang.rouleatt.controller;
+
+import com.kimandkang.rouleatt.dto.RestaurantResponse;
+import com.kimandkang.rouleatt.service.RestaurantService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/restaurants")
+@RequiredArgsConstructor
+public class RestaurantController {
+
+    private final RestaurantService restaurantService;
+
+    @GetMapping("/nearby")
+    public List<RestaurantResponse> findNearbyRestaurants(
+            @RequestParam double x,
+            @RequestParam double y,
+            @RequestParam(defaultValue = "500", name = "d") double distance
+    ) {
+        return restaurantService.findNearbyRestaurants(x, y, distance);
+    }
+}

--- a/src/main/java/com/kimandkang/rouleatt/controller/RestaurantController.java
+++ b/src/main/java/com/kimandkang/rouleatt/controller/RestaurantController.java
@@ -1,6 +1,6 @@
 package com.kimandkang.rouleatt.controller;
 
-import com.kimandkang.rouleatt.dto.RestaurantResponse;
+import com.kimandkang.rouleatt.dto.RestaurantResponses;
 import com.kimandkang.rouleatt.service.RestaurantService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -17,11 +17,12 @@ public class RestaurantController {
     private final RestaurantService restaurantService;
 
     @GetMapping("/nearby")
-    public List<RestaurantResponse> findNearbyRestaurants(
+    public RestaurantResponses findNearbyRestaurants(
             @RequestParam double x,
             @RequestParam double y,
-            @RequestParam(defaultValue = "500", name = "d") double distance
+            @RequestParam(defaultValue = "500", name = "d") double distance,
+            @RequestParam(required = false, name = "e") List<String> exclusions
     ) {
-        return restaurantService.findNearbyRestaurants(x, y, distance);
+        return restaurantService.findNearbyRestaurants(x, y, distance, exclusions);
     }
 }

--- a/src/main/java/com/kimandkang/rouleatt/domain/Restaurant.java
+++ b/src/main/java/com/kimandkang/rouleatt/domain/Restaurant.java
@@ -1,0 +1,44 @@
+package com.kimandkang.rouleatt.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@Table(indexes = {@Index(name = "idx_location", columnList = "location")})
+@Entity
+public class Restaurant {
+
+    @Id
+    private Long id;
+
+    private String name;
+
+    @Column(nullable = false, columnDefinition = "POINT SRID 4326")
+    private Point coordinate;
+
+    private String category;
+
+    private String address;
+
+    @Column(name = "road_address")
+    private String roadAddress;
+
+    public String getLocation() {
+        return coordinate.toText();
+    }
+}
+

--- a/src/main/java/com/kimandkang/rouleatt/domain/Restaurant.java
+++ b/src/main/java/com/kimandkang/rouleatt/domain/Restaurant.java
@@ -36,9 +36,5 @@ public class Restaurant {
 
     @Column(name = "road_address")
     private String roadAddress;
-
-    public String getLocation() {
-        return coordinate.toText();
-    }
 }
 

--- a/src/main/java/com/kimandkang/rouleatt/dto/RestaurantResponse.java
+++ b/src/main/java/com/kimandkang/rouleatt/dto/RestaurantResponse.java
@@ -1,0 +1,23 @@
+package com.kimandkang.rouleatt.dto;
+
+import com.kimandkang.rouleatt.domain.Restaurant;
+
+public record RestaurantResponse(
+        Long id,
+        String name,
+        String location,
+        String category,
+        String address,
+        String roadAddress
+) {
+    public static RestaurantResponse from(Restaurant restaurant) {
+        return new RestaurantResponse(
+                restaurant.getId(),
+                restaurant.getName(),
+                restaurant.getLocation(),
+                restaurant.getCategory(),
+                restaurant.getAddress(),
+                restaurant.getRoadAddress()
+        );
+    }
+}

--- a/src/main/java/com/kimandkang/rouleatt/dto/RestaurantResponse.java
+++ b/src/main/java/com/kimandkang/rouleatt/dto/RestaurantResponse.java
@@ -5,7 +5,8 @@ import com.kimandkang.rouleatt.domain.Restaurant;
 public record RestaurantResponse(
         Long id,
         String name,
-        String location,
+        double x,
+        double y,
         String category,
         String address,
         String roadAddress
@@ -14,7 +15,8 @@ public record RestaurantResponse(
         return new RestaurantResponse(
                 restaurant.getId(),
                 restaurant.getName(),
-                restaurant.getLocation(),
+                restaurant.getCoordinate().getX(),
+                restaurant.getCoordinate().getY(),
                 restaurant.getCategory(),
                 restaurant.getAddress(),
                 restaurant.getRoadAddress()

--- a/src/main/java/com/kimandkang/rouleatt/dto/RestaurantResponses.java
+++ b/src/main/java/com/kimandkang/rouleatt/dto/RestaurantResponses.java
@@ -1,0 +1,26 @@
+package com.kimandkang.rouleatt.dto;
+
+import com.kimandkang.rouleatt.domain.Restaurant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record RestaurantResponses(
+        Set<String> categories,
+        List<RestaurantResponse> restaurants
+) {
+    public static RestaurantResponses from(List<Restaurant> restaurants) {
+
+        Set<String> categories = restaurants.stream()
+                .map(Restaurant::getCategory)
+                .flatMap(category -> Arrays.stream(category.split(",")))
+                .collect(Collectors.toSet());
+
+        List<RestaurantResponse> restaurantResponses = restaurants.stream()
+                .map(RestaurantResponse::from)
+                .toList();
+
+        return new RestaurantResponses(categories, restaurantResponses);
+    }
+}

--- a/src/main/java/com/kimandkang/rouleatt/repository/RestaurantRepository.java
+++ b/src/main/java/com/kimandkang/rouleatt/repository/RestaurantRepository.java
@@ -1,25 +1,45 @@
 package com.kimandkang.rouleatt.repository;
 
 import com.kimandkang.rouleatt.domain.Restaurant;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import java.util.List;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
-import org.springframework.data.repository.query.Param;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RestaurantRepository extends CrudRepository<Restaurant, Long> {
+@RequiredArgsConstructor
+public class RestaurantRepository {
 
-    @Query(value = """
-                SELECT *
-                FROM restaurant r
-                WHERE ST_Contains(
-                    (ST_Buffer(ST_GeomFromText(CONCAT('POINT(', :y, ' ', :x, ')'), 4326), :distance)),
-                    r.coordinate)
-            """, nativeQuery = true)
-    List<Restaurant> findNearbyRestaurants(
-            @Param("x") double x,
-            @Param("y") double y,
-            @Param("distance") double distance
-    );
+    private final EntityManager em;
+
+    public List<Restaurant> findNearbyRestaurants(double x, double y, double distance, List<String> excepts) {
+        StringBuilder sql = new StringBuilder("""
+            SELECT * FROM restaurant r
+            WHERE ST_Contains(
+                (ST_Buffer(
+                    ST_GeomFromText(CONCAT('POINT(', :y, ' ', :x, ')'), 4326),
+                    :distance)),
+                r.coordinate)
+            """);
+
+        if (excepts != null && !excepts.isEmpty()) {
+            for (int i = 0; i < excepts.size(); i++) {
+                sql.append(" AND r.category NOT LIKE :except").append(i);
+            }
+        }
+
+        Query query = em.createNativeQuery(sql.toString(), Restaurant.class);
+        query.setParameter("x", x);
+        query.setParameter("y", y);
+        query.setParameter("distance", distance);
+
+        if (excepts != null && !excepts.isEmpty()) {
+            for (int i = 0; i < excepts.size(); i++) {
+                query.setParameter("except" + i, "%" + excepts.get(i) + "%");
+            }
+        }
+
+        return query.getResultList();
+    }
 }

--- a/src/main/java/com/kimandkang/rouleatt/repository/RestaurantRepository.java
+++ b/src/main/java/com/kimandkang/rouleatt/repository/RestaurantRepository.java
@@ -1,0 +1,25 @@
+package com.kimandkang.rouleatt.repository;
+
+import com.kimandkang.rouleatt.domain.Restaurant;
+import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RestaurantRepository extends CrudRepository<Restaurant, Long> {
+
+    @Query(value = """
+                SELECT *
+                FROM restaurant r
+                WHERE ST_Contains(
+                    (ST_Buffer(ST_GeomFromText(CONCAT('POINT(', :y, ' ', :x, ')'), 4326), :distance)),
+                    r.coordinate)
+            """, nativeQuery = true)
+    List<Restaurant> findNearbyRestaurants(
+            @Param("x") double x,
+            @Param("y") double y,
+            @Param("distance") double distance
+    );
+}

--- a/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
+++ b/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
@@ -1,0 +1,24 @@
+package com.kimandkang.rouleatt.service;
+
+import com.kimandkang.rouleatt.domain.Restaurant;
+import com.kimandkang.rouleatt.dto.RestaurantResponse;
+import com.kimandkang.rouleatt.repository.RestaurantRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RestaurantService {
+
+    private final RestaurantRepository restaurantRepository;
+
+    @Transactional(readOnly = true)
+    public List<RestaurantResponse> findNearbyRestaurants(double x, double y, double distance) {
+        return restaurantRepository.findNearbyRestaurants(x, y, distance)
+                .stream()
+                .map(RestaurantResponse::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
+++ b/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
@@ -3,7 +3,6 @@ package com.kimandkang.rouleatt.service;
 import com.kimandkang.rouleatt.domain.Restaurant;
 import com.kimandkang.rouleatt.dto.RestaurantResponses;
 import com.kimandkang.rouleatt.repository.RestaurantRepository;
-import com.kimandkang.rouleatt.utils.RestaurantUtils;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
+++ b/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
@@ -1,8 +1,9 @@
 package com.kimandkang.rouleatt.service;
 
 import com.kimandkang.rouleatt.domain.Restaurant;
-import com.kimandkang.rouleatt.dto.RestaurantResponse;
+import com.kimandkang.rouleatt.dto.RestaurantResponses;
 import com.kimandkang.rouleatt.repository.RestaurantRepository;
+import com.kimandkang.rouleatt.utils.RestaurantUtils;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,10 +16,8 @@ public class RestaurantService {
     private final RestaurantRepository restaurantRepository;
 
     @Transactional(readOnly = true)
-    public List<RestaurantResponse> findNearbyRestaurants(double x, double y, double distance) {
-        return restaurantRepository.findNearbyRestaurants(x, y, distance)
-                .stream()
-                .map(RestaurantResponse::from)
-                .toList();
+    public RestaurantResponses findNearbyRestaurants(double x, double y, double distance, List<String> exclusions) {
+        List<Restaurant> restaurants = restaurantRepository.findNearbyRestaurants(x, y, distance, exclusions);
+        return RestaurantResponses.from(restaurants);
     }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,6 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/rouleatt?autoReconnect=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: 1234

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+    profiles:
+        active: local
+    jpa:
+        properties:
+            hibernate:
+                format_sql: true
+                dialect: org.hibernate.dialect.MySQL8Dialect
+        hibernate:
+            ddl-auto: none
+        database: mysql


### PR DESCRIPTION
## 작업 내용

### 1. findNearbyRestaurants() 구현
- CrudRepository 를 상속하여 쿼리 메서드를 사용하려 했지만 에러 발생
- 카테고리에 콤마가 포함되어있어서 파라미터 바인딩에 문제가 있음
- API 개수가 많지 않기 때문에 직접 반복문으로 동적쿼리 생성하는 방식으로 해결

<br>

- ST_DISTANCE 는 공간 인덱스를 사용하지 않음
- ST_Contains, ST_Buffer 조합하여 공간 인덱스를 사용하도록 구현

<br>

- 카테고리만 따로 모아서 반환 -> 프론트에서 파싱하지 않고 바로 추출할 수 있으니 쿼리 파라미터에 담기 쉬워짐
