### PR TITLE
fix: MySQL 리스트 null 검사 불가로 코드로 분기처리

### DIFF
--- a/src/main/java/com/kimandkang/rouleatt/controller/RestaurantController.java
+++ b/src/main/java/com/kimandkang/rouleatt/controller/RestaurantController.java
@@ -23,6 +23,15 @@ public class RestaurantController {
             @RequestParam(defaultValue = "100", name = "distance") double distance,
             @RequestParam(required = false, name = "exclude") List<String> exclude
     ) {
-        return restaurantService.findNearbyRestaurants(x, y, distance, exclude);
+        // 거리가 벗어날 경우
+        if (distance < 100 || distance > 1000) {
+            distance = 100;
+        }
+        // 제외할 카테고리가 존재하지 않을 경우
+        if (exclude == null || exclude.isEmpty()) {
+            return restaurantService.findNearbyRestaurantsWithoutExclude(x, y, distance);
+        }
+        // 제외할 카테고리가 존재할 경우
+        return restaurantService.findNearbyRestaurantsWithExclude(x, y, distance, exclude);
     }
 }

--- a/src/main/java/com/kimandkang/rouleatt/repository/RestaurantRepository.java
+++ b/src/main/java/com/kimandkang/rouleatt/repository/RestaurantRepository.java
@@ -13,10 +13,23 @@ public interface RestaurantRepository extends CrudRepository<Restaurant, Long> {
                 FROM restaurant r
                 WHERE ST_Contains(
                     (ST_Buffer(ST_GeomFromText(CONCAT('POINT(', :y, ' ', :x, ')'), 4326), :distance)),
+                    r.coordinate)
+            """, nativeQuery = true)
+    List<Restaurant> findNearbyRestaurantsWithoutExclude(
+            @Param("x") double x,
+            @Param("y") double y,
+            @Param("distance") double distance
+    );
+
+    @Query(value = """
+                SELECT *
+                FROM restaurant r
+                WHERE ST_Contains(
+                    (ST_Buffer(ST_GeomFromText(CONCAT('POINT(', :y, ' ', :x, ')'), 4326), :distance)),
                     r.coordinate) 
                     AND r.category NOT IN :exclude
             """, nativeQuery = true)
-    List<Restaurant> findNearbyRestaurants(
+    List<Restaurant> findNearbyRestaurantsWithExclude(
             @Param("x") double x,
             @Param("y") double y,
             @Param("distance") double distance,

--- a/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
+++ b/src/main/java/com/kimandkang/rouleatt/service/RestaurantService.java
@@ -15,8 +15,14 @@ public class RestaurantService {
     private final RestaurantRepository restaurantRepository;
 
     @Transactional(readOnly = true)
-    public RestaurantResponses findNearbyRestaurants(double x, double y, double distance, List<String> exclude) {
-        List<Restaurant> restaurants = restaurantRepository.findNearbyRestaurants(x, y, distance, exclude);
+    public RestaurantResponses findNearbyRestaurantsWithoutExclude(double x, double y, double distance) {
+        List<Restaurant> restaurants = restaurantRepository.findNearbyRestaurantsWithoutExclude(x, y, distance);
+        return RestaurantResponses.from(restaurants);
+    }
+
+    @Transactional(readOnly = true)
+    public RestaurantResponses findNearbyRestaurantsWithExclude(double x, double y, double distance, List<String> exclude) {
+        List<Restaurant> restaurants = restaurantRepository.findNearbyRestaurantsWithExclude(x, y, distance, exclude);
         return RestaurantResponses.from(restaurants);
     }
 }


### PR DESCRIPTION
## 작업 내용
- 카테고리에 콤마가 포함되어 있어서 IN 조건 사용 불가
- 컨트롤러에서 카테고리 조건 유무를 판단하여 분기 처리 
- 그에 따라 서비스, 리포지토리도 메서드 분리